### PR TITLE
windows: support osCopyDirRecursive

### DIFF
--- a/lib/fs-recursive.js
+++ b/lib/fs-recursive.js
@@ -13,24 +13,33 @@ for (var key in WRENCH) {
 
 
 exports.osCopyDirRecursive = function(fromPath, toPath) {
-    
     var deferred = Q.defer();
 
     if (!PATH.existsSync(toPath)) {
         FS.mkdirSync(toPath);
     }
 
-    // NOTE: This does not copy dir on Ubuntu as it does on OSX: `"cp -R " + fromPath + "/ " + toPath`
-    // @see http://superuser.com/questions/215514/in-ubuntu-how-to-copy-all-contents-of-a-folder-to-another-folder
-    EXEC("tar pcf - .| (cd " + toPath + "; tar pxf -)", {
-        cwd: fromPath
-    }, function(err, stdout, stderr) {
-        if (err) {
-            deferred.reject(err);
-            return;
-        }
-        deferred.resolve();
-    });
+    if (process.platform == "win32") {
+        WRENCH.copyDirRecursive(fromPath, toPath, function(err) {
+            if (err) {
+                deferred.reject(err);
+                return;
+            }
+            deferred.resolve();
+        });
+    } else {
+        // NOTE: This does not copy dir on Ubuntu as it does on OSX: `"cp -R " + fromPath + "/ " + toPath`
+        // @see http://superuser.com/questions/215514/in-ubuntu-how-to-copy-all-contents-of-a-folder-to-another-folder
+        EXEC("tar pcf - .| (cd " + toPath + "; tar pxf -)", {
+            cwd: fromPath
+        }, function(err, stdout, stderr) {
+            if (err) {
+                deferred.reject(err);
+                return;
+            }
+            deferred.resolve();
+        });
+    }
     
     return deferred.promise;
 


### PR DESCRIPTION
Use WRENCH.copyDirRecursive since windows does not have a tar command
installed by default.
